### PR TITLE
chore: add `.gitignore` and `.npmignore` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/node_modules/
+/__snapshots__/
+/coverage/
+*.d.ts
+*.js
+*.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules/
-/__snapshots__/
 /coverage/
 *.d.ts
 *.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.d.ts
 *.js
 *.js.map
+
+!/types/**/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+/.github/
+/.git/
+/.gitignore
+
+/node_modules/
+/coverage/
+/tsconfig.json
+/test/
+*.js.map
+*.ts
+
+!*.d.ts


### PR DESCRIPTION
- Create .gitignore file to exclude development and build artifacts from version control
- Create .npmignore file to exclude development files and configuration from npm package
- Define patterns to ignore specific file types and directories for both Git and npm