### PR TITLE
refactor: create TypeScript type definition for snapshot chain calling

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+import { Assertion } from 'chai';
+
+declare global {
+  namespace Chai {
+    interface Assertion {
+      snapshot(): void;
+    }
+  }
+}


### PR DESCRIPTION
Extend Chai Assertion interface with `snapshot()` method