### PR TITLE
build(deps): support chai 4.x and 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
-        "chai": "5.x"
+        "chai": "4.x - 5.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "chai": "5.x"
+    "chai": "4.x - 5.x"
   },
   "dependencies": {
     "snap-shot-it": "^7.9.10"


### PR DESCRIPTION
- Update peer dependency for chai from "5.x" to "4.x - 5.x" in package.json
- Update peer dependency for chai from "5.x" to "4.x - 5.x" in package-lock.json