### PR TITLE
ci(release): release when `build`, `chore`, `docs`

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,25 @@
         "main"
     ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "releaseRules": [
+                    {
+                        "type": "build",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "chore",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "docs",
+                        "release": "patch"
+                    }
+                ]
+            }
+        ],
         "@semantic-release/release-notes-generator",
         [
             "@semantic-release/changelog",


### PR DESCRIPTION
- Add release rules for 'build', 'chore', and 'docs' commit types
- Configure these commits to trigger a 'patch' release